### PR TITLE
Implementación para un simulador de dados

### DIFF
--- a/app/Http/Controllers/DiceController.php
+++ b/app/Http/Controllers/DiceController.php
@@ -50,10 +50,9 @@ class DiceController extends Controller
     {
         /* Accumulator object to store partial results of rolls. */
         $result = [
-            "dice"    => 0,   /* Number of dice that were roll in total. */
-            "outcomes" => [], /* Outcome for rolled die $i. */
-            "size"     => [], /* Number of faces in rolled die $i. */
-            "sum"      => 0,  /* Sum of all outcomes. */
+            "dice"  => 0,  /* Number of dice that were roll in total. */
+            "rolls" => [], /* Outcomes for each die that was rolled. */
+            "sum"   => 0,  /* Sum of all outcomes. */
         ];
 
         $rolls = explode(",", strtolower($rollSet));
@@ -67,9 +66,11 @@ class DiceController extends Controller
 
                 /* Update the result accumulators. */
                 $result["dice"]++;
-                $result["outcomes"][] = $randomValue;
-                $result["size"][]     = intval($facesInDie);
-                $result["sum"]       += $randomValue;
+                $result["rolls"][] = [
+                    "size"    => intval($facesInDie),
+                    "outcome" => $randomValue,
+                ];
+                $result["sum"] += $randomValue;
             }
         }
         return $result;

--- a/app/Http/Controllers/DiceController.php
+++ b/app/Http/Controllers/DiceController.php
@@ -40,7 +40,7 @@ class DiceController extends Controller
      * it is valid or at least not malformed. The combination is a string
      * of comma separated rolls, each roll having the form xDy, where x and y
      * being natural numbers with different meanings. We will ignore the
-     * dice semantics here and accept any kind of dices for the moment, so
+     * dice semantics here and accept any kind of dice for the moment, so
      * rolls such as 10d25 or 13D26 are totally valid here.
      *
      * @param string $rollSet the list of rolls to yield.
@@ -50,25 +50,25 @@ class DiceController extends Controller
     {
         /* Accumulator object to store partial results of rolls. */
         $result = [
-            "dices"    => 0,  /* Number of dices that were roll in total. */
-            "outcomes" => [], /* Outcome for rolled dice $i. */
-            "size"     => [], /* Number of faces in rolled dice $i. */
+            "dice"    => 0,   /* Number of dice that were roll in total. */
+            "outcomes" => [], /* Outcome for rolled die $i. */
+            "size"     => [], /* Number of faces in rolled die $i. */
             "sum"      => 0,  /* Sum of all outcomes. */
         ];
 
         $rolls = explode(",", strtolower($rollSet));
         foreach ($rolls as $roll) {
-            /* Decode the command to see how many dices to roll. */
-            [$dicesToRoll, $facesInDice] = explode("d", $roll);
+            /* Decode the command to see how many dice to roll. */
+            [$diceToRoll, $facesInDie] = explode("d", $roll);
 
-            /* Always roll each dice separately, even if more than one. */
-            for ($i = 0; $i < $dicesToRoll; $i++) {
-                $randomValue = random_int(1, $facesInDice);
+            /* Always roll each die separately, even if more than one. */
+            for ($i = 0; $i < $diceToRoll; $i++) {
+                $randomValue = random_int(1, $facesInDie);
 
                 /* Update the result accumulators. */
-                $result["dices"]++;
+                $result["dice"]++;
                 $result["outcomes"][] = $randomValue;
-                $result["size"][]     = intval($facesInDice);
+                $result["size"][]     = intval($facesInDie);
                 $result["sum"]       += $randomValue;
             }
         }

--- a/app/Http/Controllers/DiceController.php
+++ b/app/Http/Controllers/DiceController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Validator;
+use Illuminate\Http\Request;
+
+class DiceController extends Controller
+{
+    public function roll(Request $request)
+    {
+        /*
+         * /\d+d\d+/ matches for a single command (1d10, 5d5, 10d20...)
+         * $diceRegex matches for either a roll or a comma separated list.
+         * Note that this doesn't capture. It is just used for validation.
+         */
+        $diceRegex = "/^\d+d\d+(,\d+d\d+)*$/i";
+
+        $validator = Validator::make($request->all(), [
+            "q" => ["required", "regex:$diceRegex"],
+        ], [
+            /* Provide more friendly messages when q is not valid. */
+            "q.required" => "You must provide a roll set.",
+            "q.regex" => "You provided an invalid roll set.",
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                "errors" => $validator->errors()->all(),
+            ], 422);
+        }
+
+        $rollCommand = strtolower($request->get("q"));
+        return response()->json($this->processRoll($rollCommand));
+    }
+
+    /**
+     * Actually processes a roll set combination.
+     *
+     * This function assumes that the roll set has already be validated and
+     * it is valid or at least not malformed. The combination is a string
+     * of comma separated rolls, each roll having the form xDy, where x and y
+     * being natural numbers with different meanings. We will ignore the
+     * dice semantics here and accept any kind of dices for the moment, so
+     * rolls such as 10d25 or 13D26 are totally valid here.
+     *
+     * @param string $rollSet the list of rolls to yield.
+     * @return array processed list of rolls.
+     */
+    private function processRoll(string $rollSet)
+    {
+        /* Accumulator object to store partial results of rolls. */
+        $result = [
+            "dices"    => 0,  /* Number of dices that were roll in total. */
+            "outcomes" => [], /* Outcome for rolled dice $i. */
+            "size"     => [], /* Number of faces in rolled dice $i. */
+            "sum"      => 0,  /* Sum of all outcomes. */
+        ];
+
+        $rolls = explode(",", strtolower($rollSet));
+        foreach ($rolls as $roll) {
+            /* Decode the command to see how many dices to roll. */
+            [$dicesToRoll, $facesInDice] = explode("d", $roll);
+
+            /* Always roll each dice separately, even if more than one. */
+            for ($i = 0; $i < $dicesToRoll; $i++) {
+                $randomValue = random_int(1, $facesInDice);
+
+                /* Update the result accumulators. */
+                $result["dices"]++;
+                $result["outcomes"][] = $randomValue;
+                $result["size"][]     = intval($facesInDice);
+                $result["sum"]       += $randomValue;
+            }
+        }
+        return $result;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,3 +16,4 @@ use Illuminate\Http\Request;
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
+Route::get('/roll', 'DiceController@roll');

--- a/tests/Feature/DiceControllerTest.php
+++ b/tests/Feature/DiceControllerTest.php
@@ -40,13 +40,13 @@ class DiceController extends TestCase
 
     /**
      * Test case that extracts deterministic properties for a single roll.
-     * Only the number of rolled dices and the faces in the dice are tested.
+     * Only the number of rolled die and the faces in the die are tested.
      */
     public function testEndpointYieldsNumberOfDicesSimple()
     {
         $response = $this->get('/api/roll?q=1d6');
         $response->assertJson([
-            "dices" => 1,
+            "dice" => 1,
             "size" => [6],
         ]);
     }
@@ -55,27 +55,27 @@ class DiceController extends TestCase
     {
         $response = $this->get('/api/roll?q=1d6,1D10,1d5');
         $response->assertJson([
-            "dices" => 3,
+            "dice" => 3,
             "size" => [6, 10, 5],
         ]);
     }
 
     /**
-     * Test case that extracts deterministic properties for multiple dices.
+     * Test case that extracts deterministic properties for multiple dice.
      * This test case is important because if you pass a xDy value, with x>1,
-     * you have to test that the system treats it as multiple dices.
+     * you have to test that the system treats it as multiple dice.
      */
     public function testEndpointYieldsNumberOfDicesMultiple()
     {
         $response = $this->get('/api/roll?q=2d5');
         $response->assertJson([
-            "dices" => 2,
+            "dice" => 2,
             "size" => [5, 5],
         ]);
     }
 
     /**
-     * Test case that extracts deterministic properties for a list of dices.
+     * Test case that extracts deterministic properties for a list of dice.
      * This test case is important because the ordering for the size and
      * outcome array in the response is important.
      */
@@ -83,7 +83,7 @@ class DiceController extends TestCase
     {
         $response = $this->get('/api/roll?q=1d6,2d10');
         $response->assertJson([
-            "dices" => 3,
+            "dice" => 3,
             "size" => [6, 10, 10],
         ]);
     }

--- a/tests/Feature/DiceControllerTest.php
+++ b/tests/Feature/DiceControllerTest.php
@@ -39,6 +39,19 @@ class DiceController extends TestCase
     }
 
     /**
+     * Test case that sums the outcomes and tests it is correct.
+     */
+    public function testEndpointSumsTheOutcomes()
+    {
+        $response = $this->get('/api/roll?q=2d6');
+        $content = $response->getOriginalContent();
+        $outcome1 = $content["rolls"][0]["outcome"];
+        $outcome2 = $content["rolls"][1]["outcome"];
+        $sum = $content["sum"];
+        $this->assertEquals($sum, $outcome1 + $outcome2);
+    }
+
+    /**
      * Test case that extracts deterministic properties for a single roll.
      * Only the number of rolled die and the faces in the die are tested.
      */
@@ -47,8 +60,10 @@ class DiceController extends TestCase
         $response = $this->get('/api/roll?q=1d6');
         $response->assertJson([
             "dice" => 1,
-            "size" => [6],
         ]);
+        $content = $response->getOriginalContent();
+        $this->assertCount(1, $content["rolls"]);
+        $this->assertEquals($content["rolls"][0]["size"], 6);
     }
 
     public function testEndpointAcceptsUppercaseCommands()
@@ -56,8 +71,12 @@ class DiceController extends TestCase
         $response = $this->get('/api/roll?q=1d6,1D10,1d5');
         $response->assertJson([
             "dice" => 3,
-            "size" => [6, 10, 5],
         ]);
+        $content = $response->getOriginalContent();
+        $this->assertCount(3, $content["rolls"]);
+        $this->assertEquals($content["rolls"][0]["size"], 6);
+        $this->assertEquals($content["rolls"][1]["size"], 10);
+        $this->assertEquals($content["rolls"][2]["size"], 5);
     }
 
     /**
@@ -70,8 +89,11 @@ class DiceController extends TestCase
         $response = $this->get('/api/roll?q=2d5');
         $response->assertJson([
             "dice" => 2,
-            "size" => [5, 5],
         ]);
+        $content = $response->getOriginalContent();
+        $this->assertCount(2, $content["rolls"]);
+        $this->assertEquals($content["rolls"][0]["size"], 5);
+        $this->assertEquals($content["rolls"][1]["size"], 5);
     }
 
     /**
@@ -84,7 +106,12 @@ class DiceController extends TestCase
         $response = $this->get('/api/roll?q=1d6,2d10');
         $response->assertJson([
             "dice" => 3,
-            "size" => [6, 10, 10],
         ]);
+        $content = $response->getOriginalContent();
+        $this->assertArrayHasKey("rolls", $content);
+        $this->assertCount(3, $content["rolls"]);
+        $this->assertEquals($content["rolls"][0]["size"], 6);
+        $this->assertEquals($content["rolls"][1]["size"], 10);
+        $this->assertEquals($content["rolls"][2]["size"], 10);
     }
 }

--- a/tests/Feature/DiceControllerTest.php
+++ b/tests/Feature/DiceControllerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class DiceController extends TestCase
+{
+    /**
+     * Test case missing any querystring parameters, including q.
+     * If you don't provide q, the endpoint will yield an error.
+     */
+    public function testEndpointYieldsErrorIfNoQueryGiven()
+    {
+        $response = $this->get('/api/roll');
+        $response->assertStatus(422);
+    }
+
+    /**
+     * Test case with an invalid query format for q.
+     * If you don't provide a valid roll command list, it will fail.
+     */
+    public function testEndpointYieldsErrorIfInvalidQueryGiven()
+    {
+        $response = $this->get('/api/roll?q=Invalid');
+        $response->assertStatus(422);
+    }
+
+    /**
+     * Test case with a valid query format for q.
+     * If you provide a valid format for q, it will succeed.
+     */
+    public function testEndpointSucceedsIfValidQueryGiven()
+    {
+        $response = $this->get('/api/roll?q=1d10');
+        $response->assertStatus(200);
+    }
+
+    /**
+     * Test case that extracts deterministic properties for a single roll.
+     * Only the number of rolled dices and the faces in the dice are tested.
+     */
+    public function testEndpointYieldsNumberOfDicesSimple()
+    {
+        $response = $this->get('/api/roll?q=1d6');
+        $response->assertJson([
+            "dices" => 1,
+            "size" => [6],
+        ]);
+    }
+
+    public function testEndpointAcceptsUppercaseCommands()
+    {
+        $response = $this->get('/api/roll?q=1d6,1D10,1d5');
+        $response->assertJson([
+            "dices" => 3,
+            "size" => [6, 10, 5],
+        ]);
+    }
+
+    /**
+     * Test case that extracts deterministic properties for multiple dices.
+     * This test case is important because if you pass a xDy value, with x>1,
+     * you have to test that the system treats it as multiple dices.
+     */
+    public function testEndpointYieldsNumberOfDicesMultiple()
+    {
+        $response = $this->get('/api/roll?q=2d5');
+        $response->assertJson([
+            "dices" => 2,
+            "size" => [5, 5],
+        ]);
+    }
+
+    /**
+     * Test case that extracts deterministic properties for a list of dices.
+     * This test case is important because the ordering for the size and
+     * outcome array in the response is important.
+     */
+    public function testEndpointYieldsNumberOfDicesList()
+    {
+        $response = $this->get('/api/roll?q=1d6,2d10');
+        $response->assertJson([
+            "dices" => 3,
+            "size" => [6, 10, 10],
+        ]);
+    }
+}


### PR DESCRIPTION
> ⚠️  Partamos de la base de que todo en este endpoint podría estar mal y que por ello debería ser cautelosamente revisado para comprobar que sigue las normas o que no hace alguna pirula extraña que deba ser corregida.

## Resumen

Este Pull Request incorpora una acción para simular el lanzamiento de dados.

## Funcionamiento de la API

El endpoint está declarado como `/api/roll` y acepta una cadena de dados a procesar a través del query param `q`. Este query param es validado y debe tener como valor un string con el formato adecuado, usando la [notación estandar para dados de rol sin modificadores](https://es.wikipedia.org/wiki/Dados_de_rol#Notaci%C3%B3n).

Sea una **secuencia** un string de la forma `xDy`, cuyo significado es _lanzar `x` dados de `y` caras_, el parámetro q puede ser una secuencia, o una lista separada por comas de secuencias. Si lo que se le proporciona no es válido, el endpoint devuelve un error directamente.

Ejemplos de llamadas válidas:

* `http://localhost:8000/api/roll?q=1d10`
* `http://localhost:8000/api/roll?q=2D6`
* `http://localhost:8000/api/roll?q=1d6,1d5,1d4`

Ejemplos de llamadas inválidas:

* `http://localhost:8000/api/roll`
* `http://localhost:8000/api/roll?troll`
* `http://localhost:8000/api/roll?q=corazon%20latino`

Cuando la llamada es válida, el endpoint procesa los lanzamientos de los dados y devuelve un objeto con el siguiente formato:

```json
{
    "dices": 2,
    "outcomes": [5, 4],
    "size": [5, 6],
    "sum": 9
}
```

en el que:

* `dices` es el número total de dados que se han lanzado.
* `outcomes` es un array con el resultado obtenido para cada dado.
* `size` es un array con el número de caras de cada dado.
* `sum` es la suma de los resultados obtenidos para cada dado.

Los arrays outcomes y sizes coinciden en ordenación. En otras palabras, para cada dado `i` que se ha tirado, `size[i]` es el número de caras del dado i, y `outcomes[i]` es el valor obtenido en el dado i.

No he considerado apropiado usar una estructura más refinada para preservar el orden, al considerar que en la vida real, la entropía propia del hecho de lanzar un dado en una mesa hace que sea impredecible la posición final de cada uno de estos, así que nada te puede garantizar que de izquierda a derecha, los dados que hayas lanzado coincidan en orden con la secuencia planeada.

Cuando la llamada no es válida, el endpoint devuelve un objeto JSON con un único key denominado `errors`, que es un array con la representación de los distintos errores que se han obtenido:

```json
{
    "errors": [
        "You must provide a roll set."
    ]
}
```

## Detalles de implementación

Tal como se comenta en #1, es importantísimo que si se procesa una secuencia de la forma `2d10`, como es una manera simbólica de representar lo mismo que `1d10,1d10`, se tiren realmente dos dados en el rango [1,10]. Lanzar un único dado en el rango [2,20] estaría mal.

El lanzamiento de dados se hace en este momento mediante llamadas directas a la función [`random_int`](https://www.php.net/manual/es/function.random-int.php), ya que la documentación aclara que en PHP 7 esta función es criptográficamente segura para generar números pseudo-aleatorios tales como desordenar una baraja de cartas, al usar `/dev/urandom` o APIs similares.

## Puntos flacos de este código

Testeo aquello que sea determinista. Por ejemplo, que si `q=2d5,1d4`, se cumpla que `dices` equivale a 3, y que `sizes` equivale a `[5, 5, 4]`. Testear código pseudoaleatorio es frágil de naturaleza.

Sin embargo, hacer un test de estrés que simule el lanzamiento de 1000 dados y que compruebe que se obtienen unos resultados estadísticamente aceptables podría estar bien. Por ejemplo, que si haces un lanzamiento 1000d10 y agrupas los resultados por valor, cada uno de los valores debe rondar el 10% de ocurrencias dentro de la distribución.

Por otra parte, se podrían hacer tests de propiedades que aseguren que al código no se le va a ir y va a devolver un outcome superior al número de caras del dado. Sin embargo, normalmente los lenguajes de programación y las librerías de testeo tradicionales para tests unitarios no incluyen la API para hacer fáciles de redactar este tipo de tests.

Al margen de esto, los nombres de las variables y de las funciones también pueden ser mejorables, ya que no conozco si existen mejores palabras que `$command` para referirse al acto de lanzar dados, por ejemplo.