### PR TITLE
fix:fix malformed merge makes syntax error

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -19,7 +19,6 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 });
 
 Route::resource('users', 'User\UserController')->except([ 'create', 'edit' ]);
-});
 Route::get('/roll', 'DiceController@roll');
 Route::prefix('xp')->group(function () {
     Route::get('maneuver', 'XPController@getManeuverXP');


### PR DESCRIPTION
Un conflicto mal resuelto había provocado unas líneas que arrojaban errores de sintaxis.