### PR TITLE
fix: migraciones tienen errores que impiden hacer rollback

### DIFF
--- a/database/migrations/2019_09_08_114630_cultures_skills.php
+++ b/database/migrations/2019_09_08_114630_cultures_skills.php
@@ -34,8 +34,8 @@ class CulturesSkills extends Migration
      * @return void
      */
     public function down()
-    {   
-        Schema::dropIfExists('culture_skill');
-        Schema::dropIfExists('culture_skill_category');
+    {
+        Schema::dropIfExists('culture_skills');
+        Schema::dropIfExists('culture_skill_categories');
     }
 }

--- a/database/migrations/2019_09_14_200743_professions.php
+++ b/database/migrations/2019_09_14_200743_professions.php
@@ -12,7 +12,7 @@ class Professions extends Migration
      * @return void
      */
     public function up()
-    {   
+    {
         $stats_list = config('rolemaster.stats_codes');
         $spell_user_types = config('rolemaster.spell_user');
         Schema::create('professions', function (Blueprint $table) use ($stats_list, $spell_user_types) {
@@ -33,6 +33,6 @@ class Professions extends Migration
      */
     public function down()
     {
-        //
+        Schema::dropIfExists('professions');
     }
 }


### PR DESCRIPTION
This PR fixes some down() methods on some existing migrations that cause
some tables to not actually be removed during the rollback process,
causing a sequence of migrate-rollback-migrate to not work.