### PR TITLE
feat: crea modelos para Campaña y Aventura

### DIFF
--- a/app/Adventure.php
+++ b/app/Adventure.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Adventure extends Model
+{
+    public function campaign()
+    {
+        return $this->belongsTo('App\Campaign');
+    }
+}

--- a/app/Campaign.php
+++ b/app/Campaign.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Campaign extends Model
+{
+    /**
+     * Retrieves the user that acts as a gamemaster for this campaign.
+     */
+    public function gamemaster()
+    {
+        return $this->belongsTo('App\User', 'gamemaster_id');
+    }
+}

--- a/app/Campaign.php
+++ b/app/Campaign.php
@@ -13,4 +13,12 @@ class Campaign extends Model
     {
         return $this->belongsTo('App\User', 'gamemaster_id');
     }
+
+    /**
+     * Retrieves the list of adventures associated with this campaign.
+     */
+    public function adventures()
+    {
+        return $this->hasMany('App\Adventure');
+    }
 }

--- a/database/factories/AdventureFactory.php
+++ b/database/factories/AdventureFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+use Faker\Generator as Faker;
+
+$factory->define(App\Adventure::class, function (Faker $faker) {
+    return [
+        'campaign_id' => function() {
+            return factory(App\Campaign::class)->create();
+        },
+        'title' => $faker->sentence,
+    ];
+});

--- a/database/factories/CampaignFactory.php
+++ b/database/factories/CampaignFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+use Faker\Generator as Faker;
+
+$factory->define(App\Campaign::class, function (Faker $faker) {
+    return [
+        'gamemaster_id' => function() {
+            return factory(App\User::class)->create();
+        },
+        'title' => $faker->sentence,
+    ];
+});

--- a/database/migrations/2019_11_10_114924_create_campaigns_table.php
+++ b/database/migrations/2019_11_10_114924_create_campaigns_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateCampaignsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('campaigns', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('gamemaster_id')->unsigned();
+            $table->string('title')->nullable(false);
+            $table->string('description')->nullable(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('campaigns');
+    }
+}

--- a/database/migrations/2019_11_10_114924_create_campaigns_table.php
+++ b/database/migrations/2019_11_10_114924_create_campaigns_table.php
@@ -12,7 +12,7 @@ class CreateCampaignsTable extends Migration
             $table->increments('id');
             $table->integer('gamemaster_id')->unsigned();
             $table->string('title');
-            $table->string('description')->nullable(true);
+            $table->text('description')->nullable(true);
             $table->timestamps();
         });
     }

--- a/database/migrations/2019_11_10_114924_create_campaigns_table.php
+++ b/database/migrations/2019_11_10_114924_create_campaigns_table.php
@@ -11,7 +11,7 @@ class CreateCampaignsTable extends Migration
         Schema::create('campaigns', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('gamemaster_id')->unsigned();
-            $table->string('title')->nullable(false);
+            $table->string('title');
             $table->string('description')->nullable(true);
             $table->timestamps();
         });

--- a/database/migrations/2019_11_10_184658_create_adventures_table.php
+++ b/database/migrations/2019_11_10_184658_create_adventures_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateAdventuresTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('adventures', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('campaign_id')->unsigned();
+            $table->string('title');
+            $table->string('description')->nullable('true');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('adventures');
+    }
+}

--- a/database/migrations/2019_11_10_184658_create_adventures_table.php
+++ b/database/migrations/2019_11_10_184658_create_adventures_table.php
@@ -17,7 +17,7 @@ class CreateAdventuresTable extends Migration
             $table->increments('id');
             $table->integer('campaign_id')->unsigned();
             $table->string('title');
-            $table->string('description')->nullable('true');
+            $table->text('description')->nullable('true');
             $table->timestamps();
         });
     }

--- a/tests/Unit/AdventureModelTest.php
+++ b/tests/Unit/AdventureModelTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use App\Adventure;
+use App\Campaign;
+
+class AdventureModelTest extends TestCase
+{
+    public function testLintFactory()
+    {
+        $adventure = factory(Adventure::class)->create();
+        $saved_adventure = Adventure::find($adventure->id);
+        $this->assertEquals($adventure->title, $saved_adventure->title);
+    }
+
+    public function testAdventureIsInvalidWithoutTitle()
+    {
+        $this->expectException(QueryException::class);
+        $adventure = factory(Adventure::class)->create([
+            "title" => null,
+        ]);
+    }
+
+    public function testAdventureIsInvalidWithoutCampaign()
+    {
+        $this->expectException(QueryException::class);
+        $adventure = factory(Adventure::class)->create([
+            "campaign_id" => null,
+        ]);
+    }
+
+    public function testAdventureBelongsToCampaign()
+    {
+        $campaign = factory(Campaign::class)->create();
+        $adventure = factory(Adventure::class)->create([
+            "campaign_id" => $campaign->id,
+        ]);
+        $this->assertEquals($adventure->campaign->id, $campaign->id);
+    }
+}

--- a/tests/Unit/CampaignModelTest.php
+++ b/tests/Unit/CampaignModelTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use App\Campaign;
+use App\User;
+
+class CampaignModelTest extends TestCase
+{
+    public function testLintFactory()
+    {
+        $campaign = factory(Campaign::class)->create();
+        $saved_campaign = Campaign::find($campaign->id);
+        $this->assertEquals($campaign->title, $saved_campaign->title);
+    }
+
+    public function testCampaignIsInvalidWithoutTitle()
+    {
+        $this->expectException(QueryException::class);
+        $campaign = factory(Campaign::class)->create([
+            "title" => null,
+        ]);
+    }
+
+    public function testCampaignIsInvalidWithoutGamemaster()
+    {
+        $this->expectException(QueryException::class);
+        $campaign = factory(Campaign::class)->create([
+            "gamemaster_id" => null,
+        ]);
+    }
+
+    public function testCampaignBelongsToGamemaster()
+    {
+        $user = factory(User::class)->create();
+        $campaign = factory(Campaign::class)->create([
+            "gamemaster_id" => $user->id,
+        ]);
+        $this->assertEquals($campaign->gamemaster->id, $user->id);
+    }
+}

--- a/tests/Unit/CampaignModelTest.php
+++ b/tests/Unit/CampaignModelTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
+use App\Adventure;
 use App\Campaign;
 use App\User;
 
@@ -42,5 +43,16 @@ class CampaignModelTest extends TestCase
             "gamemaster_id" => $user->id,
         ]);
         $this->assertEquals($campaign->gamemaster->id, $user->id);
+    }
+
+    public function testCampaignHasAdventures()
+    {
+        $campaign = factory(Campaign::class)->create();
+        $adventure = factory(Adventure::class)->create([
+            "campaign_id" => $campaign->id,
+        ]);
+
+        $this->assertCount(1, $campaign->adventures);
+        $this->assertEquals($campaign->adventures()->first()->id, $adventure->id);
     }
 }


### PR DESCRIPTION
Este PR introduce dos modelos, Campaña y Aventura.

## Notas de diseño

Intencionalmente he hecho que las descripciones sean obligatorias. O que puedas crear campañas y aventuras sin descripción. Normalmente no querrías, porque sirven para notas, pero es opcional igualmente.

## Metadata

Closes #4