### PR TITLE
fix: type error in CharacterController#store

### DIFF
--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -35,7 +35,7 @@ class CharacterController extends Controller
 
         $character = new Character;
 
-        $character->user_id = $request->user;
+        $character->user_id = $request->user()->id;
         $character->name = $request->name;
         $character->experience = $request->experience;
         $character->level = $this->getLevel($request->experience);


### PR DESCRIPTION
CharacterController#store is failing because it doesn't properly
retrieve the current user ID, but rather it does something completely
unrelated.