### PR TITLE
fix: usa tests transaccionales correctamente

### DIFF
--- a/tests/Feature/DiceControllerTest.php
+++ b/tests/Feature/DiceControllerTest.php
@@ -3,8 +3,6 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class DiceController extends TestCase
 {

--- a/tests/Feature/XPAPIControllerTest.php
+++ b/tests/Feature/XPAPIControllerTest.php
@@ -3,8 +3,6 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class XPAPIControllerTest extends TestCase
 {
@@ -17,13 +15,13 @@ class XPAPIControllerTest extends TestCase
 
     /**
      * Test case parameters are missing in all endpoints because
-     * all endpoints nedds at least one parameter regardless what method 
+     * all endpoints nedds at least one parameter regardless what method
      * are using.
      *
      * @return void
      */
     public function testEndpointsYieldsErrorIfNotQueryGiven()
-    {   
+    {
         foreach ($this->endpoints as $endpoint){
             $response = $this->json('GET', '/api/xp/'.$endpoint);
         }
@@ -36,7 +34,7 @@ class XPAPIControllerTest extends TestCase
      * @return void
      */
     public function testEndpointManeuverYieldsErrorIfInvalidQueryGiven()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/maneuver?man=j');
         $response->assertStatus(422);
         $response = $this->json('GET', '/api/xp/maneuver?man=mfa');
@@ -55,7 +53,7 @@ class XPAPIControllerTest extends TestCase
      * @return void
      */
     public function testEndpointManeuverSuccessIfValidQueryGiven()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/maneuver?man=mf');
         $response->assertStatus(200);
         $response = $this->json('GET', '/api/xp/maneuver?man=ab&mod=0.5');
@@ -66,11 +64,11 @@ class XPAPIControllerTest extends TestCase
 
     /**
      * Test case receiving correct values for maneuver XP
-     * 
+     *
      * @return void
      */
     public function testEndpointManeuverReturnsCorrectXPValues()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/maneuver?man=ed');
         $content = $response->getOriginalContent();
         $this->assertEquals(200, $content['message']);
@@ -88,7 +86,7 @@ class XPAPIControllerTest extends TestCase
      * @return void
      */
     public function testEndpointSpellYieldsErrorIfInvalidQueryGiven()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/spell?caster=j');
         $response->assertStatus(422);
         $response = $this->json('GET', '/api/xp/spell?caster=0');
@@ -107,18 +105,18 @@ class XPAPIControllerTest extends TestCase
      * @return void
      */
     public function testEndpointSpellSuccessIfValidQueryGiven()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/spell?caster=1&spell=12&mod=2');
         $response->assertStatus(200);
     }
 
     /**
      * Test case receiving correct values for spell XP
-     * 
+     *
      * @return void
      */
     public function testEndpointSpellReturnsCorrectXPValues()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/spell?caster=1&spell=12&mod=2');
         $content = $response->getOriginalContent();
         $this->assertEquals(400, $content['message']);
@@ -135,7 +133,7 @@ class XPAPIControllerTest extends TestCase
      * @return void
      */
     public function testEndpointTravelOrHPYieldsErrorIfInvalidQueryGiven()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/travel?base=j');
         $response->assertStatus(422);
         $response = $this->json('GET', '/api/xp/hp?base=-18');
@@ -150,18 +148,18 @@ class XPAPIControllerTest extends TestCase
      * @return void
      */
     public function testEndpointTravelOrHPSuccessIfValidQueryGiven()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/travel?base=1003&mod=12');
         $response->assertStatus(200);
     }
 
     /**
      * Test case receiving correct values for spell XP
-     * 
+     *
      * @return void
      */
     public function testEndpointTravelOrHPReturnsCorrectXPValues()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/travel?base=189');
         $content = $response->getOriginalContent();
         $this->assertEquals(189, $content['message']);
@@ -176,7 +174,7 @@ class XPAPIControllerTest extends TestCase
      * @return void
      */
     public function testEndpointCriticalYieldsErrorIfInvalidQueryGiven()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/critical?crit=j');
         $response->assertStatus(422);
         $response = $this->json('GET', '/api/xp/critical?crit=ea');
@@ -195,7 +193,7 @@ class XPAPIControllerTest extends TestCase
      * @return void
      */
     public function testEndpointCriticalSuccessIfValidQueryGiven()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/critical?crit=E&level=2');
         $response->assertStatus(200);
         $response = $this->json('GET', '/api/xp/critical?crit=a&level=5&mod=1.5');
@@ -204,11 +202,11 @@ class XPAPIControllerTest extends TestCase
 
     /**
      * Test case receiving correct values for critical XP
-     * 
+     *
      * @return void
      */
     public function testEndpointCriticalReturnsCorrectXPValues()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/critical?crit=E&level=2');
         $content = $response->getOriginalContent();
         $this->assertEquals(50, $content['message']);
@@ -226,7 +224,7 @@ class XPAPIControllerTest extends TestCase
      * @return void
      */
     public function testEndpointKillSuccessIfValidQueryGiven()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/kill?attack=8&def=2');
         $response->assertStatus(200);
         $response = $this->json('GET', '/api/xp/kill?attack=8&def=2&mod=1.5');
@@ -235,11 +233,11 @@ class XPAPIControllerTest extends TestCase
 
     /**
      * Test case receiving correct values for critical XP
-     * 
+     *
      * @return void
      */
     public function testEndpointKillReturnsCorrectXPValues()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/kill?attack=8&def=2');
         $content = $response->getOriginalContent();
         $this->assertEquals(80, $content['message']);
@@ -252,7 +250,7 @@ class XPAPIControllerTest extends TestCase
     }
 
     public function testEndpointBonusYieldsErrorIfInvalidQueryGiven()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/bonus?crit=jk$level=12');
         $response->assertStatus(422);
         $response = $this->json('GET', '/api/xp/bonus?crit=j$level=-2');
@@ -265,7 +263,7 @@ class XPAPIControllerTest extends TestCase
      * @return void
      */
     public function testEndpointBonusSuccessIfValidQueryGiven()
-    {   
+    {
         $response = $this->json('GET', '/api/xp/bonus?level=8&code=E');
         $response->assertStatus(200);
         $response = $this->json('GET', '/api/xp/bonus?level=25&code=j');
@@ -274,11 +272,11 @@ class XPAPIControllerTest extends TestCase
 
     /**
      * Test case receiving correct values for bonus XP
-     * 
+     *
      * @return void
      */
     public function testEndpointBonusReturnsCorrectXPValues()
-    {   
+    {
         $row_21 = [
             'a' => 0,
             'b' => 0,

--- a/tests/Unit/AdventureModelTest.php
+++ b/tests/Unit/AdventureModelTest.php
@@ -4,14 +4,15 @@ namespace Tests\Feature;
 
 use Tests\TestCase;
 use Illuminate\Database\QueryException;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 use App\Adventure;
 use App\Campaign;
 
 class AdventureModelTest extends TestCase
 {
+    use DatabaseTransactions;
+
     public function testLintFactory()
     {
         $adventure = factory(Adventure::class)->create();

--- a/tests/Unit/CampaignModelTest.php
+++ b/tests/Unit/CampaignModelTest.php
@@ -4,8 +4,7 @@ namespace Tests\Feature;
 
 use Tests\TestCase;
 use Illuminate\Database\QueryException;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 use App\Adventure;
 use App\Campaign;
@@ -13,6 +12,8 @@ use App\User;
 
 class CampaignModelTest extends TestCase
 {
+    use DatabaseTransactions;
+
     public function testLintFactory()
     {
         $campaign = factory(Campaign::class)->create();


### PR DESCRIPTION
Me encuentro que lanzar phpunit tiene efectos impredecibles en la base de datos.

Los tests ahora mismo no están limpiando lo que crean, como son los tests de modelo de Campaña y Aventura, así que otros tests que estoy implementando para #40 que prueban el controlador fallan todo el tiempo porque la base de datos tiene resultados de las ejecuciones de los tests anteriores.

Por otra parte, entiendo poco de Laravel pero usar RefreshDatabase está borrando los seeds que cargan datos estáticos de hechizos y demás que hay en los seeders, así que no me parece lo más óptimo si en algún momento tenemos que hacer tests que esperen que esos datos estáticos están ahí.