### PR TITLE
refactor: introduce Resources for Character and User

### DIFF
--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -4,7 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreEditCharacterRequest;
 use Illuminate\Http\Response;
+
 use App\Character;
+use App\Http\Resources\Characters\CharacterCollection;
+use App\Http\Resources\Characters\Character as CharacterResource;
 
 class CharacterController extends Controller
 {
@@ -21,7 +24,7 @@ class CharacterController extends Controller
      */
     public function index()
     {
-        return response()->json(Character::all(), 200);
+        return new CharacterCollection(Character::paginate());
     }
 
     /**
@@ -56,7 +59,7 @@ class CharacterController extends Controller
      */
     public function show(Character $character)
     {
-        return Character::findOrFail($character->id);
+        return new CharacterResource($character);
     }
 
     /**

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -2,8 +2,11 @@
 
 namespace App\Http\Controllers\User;
 
-use Auth;
 use App\User;
+use App\Http\Resources\Users\UserCollection;
+use App\Http\Resources\Users\User as UserResource;
+
+use Auth;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Hash;
@@ -22,7 +25,7 @@ class UserController extends Controller
      */
     public function index()
     {
-        return User::all();
+        return new UserCollection(User::paginate());
     }
 
     /**
@@ -64,7 +67,7 @@ class UserController extends Controller
      */
     public function show(User $user)
     {
-        return User::findOrFail($user->id);
+        return new UserResource($user);
     }
 
     /**

--- a/app/Http/Resources/Characters/Character.php
+++ b/app/Http/Resources/Characters/Character.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources\Characters;
+
+use Illuminate\Support\Facades\URL;
+use App\Http\Resources\LinkedResource;
+
+class Character extends LinkedResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'experience' => $this->experience,
+            'level' => $this->level,
+        ];
+    }
+
+    public function links($request)
+    {
+        return [
+            'self' => URL::route('characters.show', ['character' => $this->id]),
+        ];
+    }
+}

--- a/app/Http/Resources/Characters/CharacterCollection.php
+++ b/app/Http/Resources/Characters/CharacterCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources\Characters;
+
+use App\Http\Resources\LinkedCollection;
+
+class CharacterCollection extends LinkedCollection
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/app/Http/Resources/LinkedCollection.php
+++ b/app/Http/Resources/LinkedCollection.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class LinkedCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return ['data' => $this->linkedCollection($request)];
+    }
+
+    protected function linkedCollection($request)
+    {
+        return $this->collection->map(function ($resource) use ($request) {
+            return array_merge($resource->toArray($request), [
+                "links" => $resource->links($request),
+            ]);
+        });
+    }
+}

--- a/app/Http/Resources/LinkedResource.php
+++ b/app/Http/Resources/LinkedResource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class LinkedResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+
+    public function with($request)
+    {
+        return [
+            'links' => $this->links($request),
+        ];
+    }
+
+    public function links($request)
+    {
+        return [];
+    }
+}

--- a/app/Http/Resources/Users/User.php
+++ b/app/Http/Resources/Users/User.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Resources\Users;
+
+use App\Http\Resources\LinkedResource;
+use Illuminate\Support\Facades\URL;
+
+class User extends LinkedResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+        ];
+    }
+
+    public function links($request)
+    {
+        return [
+            'self' => URL::route('users.show', ['user' => $this->id]),
+        ];
+    }
+}

--- a/app/Http/Resources/Users/UserCollection.php
+++ b/app/Http/Resources/Users/UserCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources\Users;
+
+use App\Http\Resources\LinkedCollection;
+
+class UserCollection extends LinkedCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/database/factories/CharacterFactory.php
+++ b/database/factories/CharacterFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\User;
+use Faker\Generator as Faker;
+
+$factory->define(App\Character::class, function (Faker $faker) {
+    return [
+        'user_id' => factory(User::class)->create()->id,
+        'name' => $faker->name(),
+        'experience' => $faker->biasedNumberBetween(50000, 60000),
+        'level' => $faker->biasedNumberBetween(4, 6),
+    ];
+});

--- a/tests/Feature/Api/CharactersControllerTest.php
+++ b/tests/Feature/Api/CharactersControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+use App\Character;
+use App\User;
+use Tests\TestCase;
+
+class CharactersControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private $user;
+
+    private $character1;
+
+    private $character2;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = factory(User::class)->create();
+        $this->character1 = factory(Character::class)->create([
+            'name' => 'John Doe',
+            'experience' => 50000,
+            'level' => 5,
+            'user_id' => $this->user->id,
+        ]);
+        $this->character2 = factory(Character::class)->create([
+            'name' => 'Foo Bar',
+            'experience' => 55000,
+            'level' => 5,
+            'user_id' => $this->user->id,
+        ]);
+    }
+
+    public function testIndexSucceeds()
+    {
+        $this->actingAs($this->user, 'jwt')
+             ->json('get', '/api/characters')
+             ->assertStatus(200)
+             ->assertJson([
+                 'data' => [
+                     [
+                         'id' => $this->character1->id,
+                         'name' => 'John Doe',
+                         'level' => 5,
+                         'experience' => 50000,
+                     ],
+                     [
+                         'id' => $this->character2->id,
+                         'name' => 'Foo Bar',
+                         'level' => 5,
+                         'experience' => 55000,
+                     ],
+                 ]
+             ]);
+    }
+
+    public function testIndexFailsIfUnauthenticated()
+    {
+        $this->json('get', '/api/characters')
+             ->assertStatus(401);
+    }
+
+    public function testShowSucceeds()
+    {
+        $this->actingAs($this->user, 'jwt')
+             ->json('get', "/api/characters/{$this->character1->id}")
+             ->assertStatus(200)
+             ->assertJson([
+                 'data' => [
+                     'id' => $this->character1->id,
+                     'name' => 'John Doe',
+                     'level' => 5,
+                     'experience' => 50000,
+                 ]
+             ]);
+    }
+
+    public function testShowFailsIfUnauthenticated()
+    {
+        $this->json('get', "/api/characters/{$this->character1->id}")
+             ->assertStatus(401);
+    }
+
+    public function testShowFailsIfDoesNotExist()
+    {
+        $this->character1->delete();
+        $this->actingAs($this->user, 'jwt')
+             ->json('get', "/api/characters/{$this->character1->id}")
+             ->assertStatus(404);
+    }
+}

--- a/tests/Feature/Api/UsersControllerTest.php
+++ b/tests/Feature/Api/UsersControllerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+use App\User;
+use Tests\TestCase;
+
+class UsersControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private $user1;
+
+    private $user2;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Wipe seeded users to prevent ID conflicts in tests.
+        // To prevent data loss, this runs inside a transaction.
+        User::truncate();
+
+        $this->user1 = factory(User::class)->create([
+            'name' => 'John Doe',
+            'email' => 'johndoe@example.com',
+        ]);
+        $this->user2 = factory(User::class)->create([
+            'name' => 'Foo Bar',
+            'email' => 'foobar@example.com',
+        ]);
+    }
+
+    public function testIndexSucceeds()
+    {
+        $this->actingAs($this->user1, 'jwt')
+             ->json('get', '/api/users')
+             ->assertStatus(200)
+             ->assertJson([
+                 'data' => [
+                     [
+                         'id' => $this->user1->id,
+                         'name' => 'John Doe',
+                         'email' => 'johndoe@example.com',
+                     ],
+                     [
+                         'id' => $this->user2->id,
+                         'name' => 'Foo Bar',
+                         'email' => 'foobar@example.com',
+                     ],
+                 ],
+             ]);
+    }
+
+    public function testIndexFailsIfUnauthenticated()
+    {
+        $this->json('get', '/api/users')
+             ->assertStatus(401);
+    }
+
+    public function testShowSucceeds()
+    {
+        $this->actingAs($this->user1, 'jwt')
+             ->json('get', "/api/users/{$this->user1->id}")
+             ->assertStatus(200)
+             ->assertJson([
+                 'data' => [
+                     'id' => $this->user1->id,
+                     'name' => 'John Doe',
+                     'email' => 'johndoe@example.com',
+                 ],
+             ]);
+    }
+
+    public function testShowFailsIfNotExist()
+    {
+        $this->user1->delete();
+        $this->actingAs($this->user1, 'jwt')
+             ->json('get', "/api/users/{$this->user1->id}")
+             ->assertStatus(404);
+    }
+
+    public function testShowFailsIfUnauthenticated()
+    {
+        $this->json('get', "/api/users/{$this->user1->id}")
+             ->assertStatus(401);
+    }
+}


### PR DESCRIPTION
⚠️ This breaks the API schema and will require rework in openrpg-ui.
I think that the refactor will enhance things this time and that it
will be worth to address this in openrpg-ui.

This commit refactors the index and show actions of the Charater and
User controller in order to use Laravel API Resources, which will
produce a more streamlined and uniform API response format than
having each controller have a different way of sending responses.

Collections (index) make use of the ResourceCollection, which already
handles pagination for free and it's provided by Laravel. It is
robust enough to nest stuff in objects and provides out of the box
a pagination metadata object and a HATEOAS-compatible link map with
pointers to pages.

Resources (show) make use of the JsonResource to coerce a resource
into a JSON object. JsonResource plays nice and wraps the resource
into a data object.

Two base resources called LinkedCollection and LinkedResource have
been introduced in this commit.

* LinkedResource takes care of adding an extra metadata field called
  links, providing a HATEOAS-compatible link map that can be populated
  by each resource subclass.

* LinkedCollection is a base class that can be used for collections
  of linked resources, allowing the link map provided by a linked
  resource to be embedded into the data array itself.