### PR TITLE
feat: add Campaigns CRUD controller

### DIFF
--- a/app/Campaign.php
+++ b/app/Campaign.php
@@ -6,6 +6,12 @@ use Illuminate\Database\Eloquent\Model;
 
 class Campaign extends Model
 {
+    protected $fillable = [
+        'title',
+        'description',
+        'gamemaster_id',
+    ];
+
     /**
      * Retrieves the user that acts as a gamemaster for this campaign.
      */

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Campaign;
+use App\Http\Requests\Campaign\StoreCampaign;
+use App\Http\Requests\Campaign\UpdateCampaign;
+use App\Http\Resources\Campaigns\Campaign as CampaignResource;
+use App\Http\Resources\Campaigns\CampaignCollection;
+
+class CampaignsController extends ApiController
+{
+    public function index()
+    {
+        return new CampaignCollection(Campaign::paginate());
+    }
+
+    public function store(StoreCampaign $request)
+    {
+        $validated = $request->validated();
+        $validated['gamemaster_id'] = $request->user()->id;
+        $campaign = Campaign::create($validated);
+        return $this->sendMessage('Created successfully', 201)
+                    ->header('Location', route('campaigns.show', ['campaign' => $campaign]));
+    }
+
+    public function show(Campaign $campaign)
+    {
+        return new CampaignResource($campaign);
+    }
+
+    public function update(UpdateCampaign $request, Campaign $campaign)
+    {
+        $validated = $request->validated();
+        if ($campaign->update($validated)) {
+            return $this->sendMessage('Updated successfully');
+        } else {
+            return $this->sendMessage('Cannot persist changes', 422);
+        }
+    }
+
+    public function destroy(Campaign $campaign)
+    {
+        if ($campaign->delete()) {
+            return $this->sendMessage('Destroyed successfully');
+        } else {
+            return $this->sendMessage('Cannot destroy this campaign');
+        }
+    }
+}

--- a/app/Http/Controllers/CampaignsController.php
+++ b/app/Http/Controllers/CampaignsController.php
@@ -17,11 +17,14 @@ class CampaignsController extends ApiController
 
     public function store(StoreCampaign $request)
     {
-        $validated = $request->validated();
-        $validated['gamemaster_id'] = $request->user()->id;
-        $campaign = Campaign::create($validated);
-        return $this->sendMessage('Created successfully', 201)
-                    ->header('Location', route('campaigns.show', ['campaign' => $campaign]));
+        $campaign = new Campaign($request->validated());
+        $campaign->gamemaster_id = $request->user()->id;
+        if ($campaign->save()) {
+            return $this->sendMessage('Created successfully', 201)
+                        ->header('Location', route('campaigns.show', ['campaign' => $campaign]));
+        } else {
+            return $this->sendMessage('Cannot persist', 500);
+        }
     }
 
     public function show(Campaign $campaign)
@@ -35,7 +38,7 @@ class CampaignsController extends ApiController
         if ($campaign->update($validated)) {
             return $this->sendMessage('Updated successfully');
         } else {
-            return $this->sendMessage('Cannot persist changes', 422);
+            return $this->sendMessage('Cannot persist', 500);
         }
     }
 
@@ -44,7 +47,7 @@ class CampaignsController extends ApiController
         if ($campaign->delete()) {
             return $this->sendMessage('Destroyed successfully');
         } else {
-            return $this->sendMessage('Cannot destroy this campaign');
+            return $this->sendMessage('Cannot destroy', 500);
         }
     }
 }

--- a/app/Http/Requests/Campaign/StoreCampaign.php
+++ b/app/Http/Requests/Campaign/StoreCampaign.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Campaign;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCampaign extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|unique:campaigns|max:100',
+            'description' => 'nullable',
+        ];
+    }
+}

--- a/app/Http/Requests/Campaign/UpdateCampaign.php
+++ b/app/Http/Requests/Campaign/UpdateCampaign.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Campaign;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCampaign extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'sometimes|required|unique:campaigns|max:100',
+            'description' => 'nullable',
+        ];
+    }
+}

--- a/app/Http/Resources/Campaigns/Campaign.php
+++ b/app/Http/Resources/Campaigns/Campaign.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Resources\Campaigns;
+
+use App\Http\Resources\LinkedResource;
+use Illuminate\Support\Facades\URL;
+
+class Campaign extends LinkedResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'description' => $this->description,
+        ];
+    }
+
+    public function links($request)
+    {
+        return [
+            'self' => URL::route('campaigns.show', ['campaign' => $this->id]),
+        ];
+    }
+}

--- a/app/Http/Resources/Campaigns/CampaignCollection.php
+++ b/app/Http/Resources/Campaigns/CampaignCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources\Campaigns;
+
+use App\Http\Resources\LinkedCollection;
+
+class CampaignCollection extends LinkedCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,7 @@ Route::apiResource("spell-lists", 'SpellListController');
 Route::apiResource("spells", 'SpellController');
 Route::apiResource('users', 'User\UserController');
 Route::apiResource('characters', 'CharacterController');
+Route::apiResource('campaigns', 'CampaignsController');
 
 Route::prefix('auth')->group(function() {
     Route::resource('sessions', 'Api\Auth\SessionsController')->only(['store']);

--- a/tests/Feature/Api/CampaignsControllerTest.php
+++ b/tests/Feature/Api/CampaignsControllerTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+use App\User;
+use App\Campaign;
+
+class CampaignsControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected $gamemaster;
+
+    protected $campaign1;
+
+    protected $campaign2;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->gamemaster = factory(User::class)->create();
+        $this->campaign1 = factory(Campaign::class)->create([
+            'title' => 'The Lord of the Rings',
+            'description' => 'The original, except we slaughtered the book',
+            'gamemaster_id' => $this->gamemaster->id,
+        ]);
+        $this->campaign2 = factory(Campaign::class)->create([
+            'title' => 'Dungeons and Dragons',
+            'description' => 'I mean is a classic',
+            'gamemaster_id' => $this->gamemaster->id,
+        ]);
+    }
+
+    public function testIndexSucceeds()
+    {
+        $this->actingAs($this->gamemaster, 'jwt')
+             ->json('get', '/api/campaigns')
+             ->assertStatus(200)
+             ->assertJson([
+                 'data' => [
+                     [
+                         'id' => $this->campaign1->id,
+                         'title' => 'The Lord of the Rings',
+                         'description' => 'The original, except we slaughtered the book',
+                     ],
+                     [
+                         'id' => $this->campaign2->id,
+                         'title' => 'Dungeons and Dragons',
+                         'description' => 'I mean is a classic',
+                     ],
+                 ],
+             ]);
+    }
+
+    public function testIndexFailsIfNotAuthenticated()
+    {
+        $this->json('get', '/api/campaigns')
+             ->assertStatus(401);
+    }
+
+    public function testShowSucceeds()
+    {
+        $this->actingAs($this->gamemaster, 'jwt')
+             ->json('get', "/api/campaigns/{$this->campaign1->id}")
+             ->assertStatus(200)
+             ->assertJson([
+                 'data' => [
+                     'id' => $this->campaign1->id,
+                     'title' => 'The Lord of the Rings',
+                     'description' => 'The original, except we slaughtered the book',
+                 ],
+             ]);
+    }
+
+    public function testShowFailsIfUnauthenticated()
+    {
+        $this->json('get', "/api/campaigns/{$this->campaign1->id}")
+             ->assertStatus(401);
+    }
+
+    public function testShowFailsIfNotExists()
+    {
+        $this->campaign1->delete();
+        $this->actingAs($this->gamemaster, 'jwt')
+             ->json('get', "/api/campaigns/{$this->campaign1->id}")
+             ->assertStatus(404);
+    }
+
+    public function testStoreSucceeds()
+    {
+        $this->actingAs($this->gamemaster, 'jwt')
+             ->json('post', '/api/campaigns', [
+                 'title' => 'Dangerous world',
+                 'description' => 'It is a dangerous world',
+             ])
+             ->assertStatus(201)
+             ->assertHeader('Location');
+
+        $this->assertDatabaseHas('campaigns', [
+            'title' => 'Dangerous world',
+            'description' => 'It is a dangerous world',
+            'gamemaster_id' => $this->gamemaster->id,
+        ]);
+    }
+
+    public function testStoreFailsIfUnauthenticated()
+    {
+        $this->json('post', '/api/campaigns')
+             ->assertStatus(401);
+    }
+
+    public function testStoreFailsIfInvalid()
+    {
+        $this->actingAs($this->gamemaster, 'jwt')
+             ->json('post', '/api/campaigns', [])
+             ->assertStatus(422);
+    }
+
+    public function testStoreIntegration()
+    {
+        $response = $this->actingAs($this->gamemaster, 'jwt')
+                         ->json('post', '/api/campaigns', [
+                             'title' => 'Dangerous world',
+                             'description' => 'It is a dangerous world',
+                         ]);
+
+        $response->assertStatus(201);
+
+        $this->actingAs($this->gamemaster, 'jwt')
+             ->json('get', $response->headers->get('Location'))
+             ->assertStatus(200)
+             ->assertJson([
+                 'data' => [
+                     'title' => 'Dangerous world',
+                     'description' => 'It is a dangerous world',
+                 ],
+             ]);
+    }
+
+    public function testUpdateSucceeds()
+    {
+        $payload = ['title' => 'Dark days are coming'];
+        $this->actingAs($this->gamemaster, 'jwt')
+             ->json('put', "/api/campaigns/{$this->campaign1->id}", $payload)
+             ->assertStatus(200);
+        $this->assertDatabaseHas('campaigns', [
+            'id' => $this->campaign1->id,
+            'title' => 'Dark days are coming',
+            'description' => 'The original, except we slaughtered the book',
+        ]);
+    }
+
+    public function testUpdateFailsIfNotValid()
+    {
+        $payload = ['title' => ''];
+        $this->actingAs($this->gamemaster, 'jwt')
+             ->json('put', "/api/campaigns/{$this->campaign1->id}", $payload)
+             ->assertStatus(422);
+    }
+
+    public function testUpdateFailsIfUnauthenticated()
+    {
+        $payload = ['title' => 'Dark days are coming'];
+        $this->json('put', "/api/campaigns/{$this->campaign1->id}", $payload)
+             ->assertStatus(401);
+    }
+
+    public function testUpdateIntegration()
+    {
+        $payload = ['title' => 'Dark days are coming'];
+        $this->actingAs($this->gamemaster, 'jwt')
+             ->json('put', "/api/campaigns/{$this->campaign1->id}", $payload)
+             ->assertStatus(200);
+        $this->actingAs($this->gamemaster, 'jwt')
+             ->json('get', "/api/campaigns/{$this->campaign1->id}")
+             ->assertStatus(200)
+             ->assertJson([
+                 'data' => [
+                     'id' => $this->campaign1->id,
+                     'title' => 'Dark days are coming',
+                     'description' => 'The original, except we slaughtered the book',
+                 ],
+             ]);
+    }
+
+    public function testDestroySucceeds()
+    {
+        $this->actingAs($this->gamemaster, 'jwt')
+             ->json('delete', "/api/campaigns/{$this->campaign1->id}")
+             ->assertStatus(200);
+        $this->assertDeleted($this->campaign1);
+    }
+
+    public function testDeleteFailsIfUnauthenticated()
+    {
+        $this->json('delete', "/api/campaigns/{$this->campaign1->id}")
+             ->assertStatus(401);
+    }
+
+    public function testDestroyIntegration()
+    {
+        $this->actingAs($this->gamemaster, 'jwt')
+             ->json('delete', "/api/campaigns/{$this->campaign1->id}")
+             ->assertStatus(200);
+        $this->actingAs($this->gamemaster, 'jwt')
+             ->json('get', "/api/campaigns/{$this->campaign1->id}")
+             ->assertStatus(404);
+    }
+}


### PR DESCRIPTION
This commit will add a controller to handle creation, retrieval,
update and deletion of campaigns. It adds a set of linked resources to
present campaigns, and a set of requests to receive campaigns.

Closes #40