### PR TITLE
fix: cannot PUT user if email is the same

### DIFF
--- a/app/Http/Requests/Users/UserUpdateRequest.php
+++ b/app/Http/Requests/Users/UserUpdateRequest.php
@@ -23,9 +23,10 @@ class UserUpdateRequest extends FormRequest
      */
     public function rules()
     {
+        $user = $this->route()->parameter('user');
         return [
             'name' => 'sometimes|required|min:4',
-            'email' => 'sometimes|required|email|unique:users,email',
+            'email' => "sometimes|required|email|unique:users,email,{$user->id}",
             'password' => 'sometimes|same:repeat_password|min:8',
             'repeat_password' => 'sometimes|same:password|min:8'
         ];

--- a/tests/Feature/Api/UsersControllerTest.php
+++ b/tests/Feature/Api/UsersControllerTest.php
@@ -82,6 +82,19 @@ class UsersControllerTest extends TestCase
              ->assertStatus(200);
     }
 
+    public function testStoreFailsIfEmailTaken()
+    {
+        $payload = [
+            'name' => 'John Smith',
+            'email' => 'foobar@example.com',
+            'password' => '12345678',
+            'repeat_password' => '12345678',
+        ];
+        $this->actingAs($this->user1, 'jwt')
+             ->json('post', '/api/users/', $payload)
+             ->assertStatus(422);
+    }
+
     public function testStoreFailsIfInvalid()
     {
         $payload = [
@@ -180,6 +193,28 @@ class UsersControllerTest extends TestCase
             'email' => 'jackdaniels@example.com',
             'password' => '00000000'
         ])
+             ->assertStatus(200);
+    }
+
+    public function testUpdateFailsIfEmailTaken()
+    {
+        $payload = [
+            'name' => 'Jack Daniels',
+            'email' => 'foobar@example.com',
+        ];
+        $this->actingAs($this->user1, 'jwt')
+             ->json('put', "/api/users/{$this->user1->id}", $payload)
+             ->assertStatus(422);
+    }
+
+    public function testUpdateSucceedsIfDoesntChangeEmail()
+    {
+        $payload = [
+            'name' => 'Jack Bauer',
+            'email' => 'johndoe@example.com',
+        ];
+        $this->actingAs($this->user1, 'jwt')
+             ->json('put', "/api/users/{$this->user1->id}", $payload)
              ->assertStatus(200);
     }
 


### PR DESCRIPTION
Found an interesting bug while backporting changes made in #62 and #63
to OpenRPG-UI. The request form used by user update requests is
rejecting a valid PUT payload where an unmodified e-mail address is
present, because the e-mail is already found in the database (as
expected, because it hasn't changed).