### PR TITLE
feat: add Adventures CRUD controller

### DIFF
--- a/app/Adventure.php
+++ b/app/Adventure.php
@@ -6,6 +6,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class Adventure extends Model
 {
+    protected $fillable = [
+        'title',
+        'description',
+    ];
+
     public function campaign()
     {
         return $this->belongsTo('App\Campaign');

--- a/app/Http/Controllers/AdventuresController.php
+++ b/app/Http/Controllers/AdventuresController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use \Illuminate\Database\Eloquent\ModelNotFoundException;
+
+use App\Adventure;
+use App\Campaign;
+use App\Http\Requests\Adventures\StoreAdventure;
+use App\Http\Requests\Adventures\UpdateAdventure;
+use App\Http\Resources\Adventures\AdventureCollection;
+use App\Http\Resources\Adventures\Adventure as AdventureResource;
+
+class AdventuresController extends ApiController
+{
+    public function index(Campaign $campaign)
+    {
+        return new AdventureCollection(Adventure::where(['campaign_id' => $campaign->id])->paginate());
+    }
+
+    public function store(StoreAdventure $request, Campaign $campaign)
+    {
+        $adventure = new Adventure($request->validated());
+        $adventure->campaign_id = $campaign->id;
+        if ($adventure->save()) {
+            return $this->sendMessage('Persisted successfully', 201)
+                        ->header('Location', route('campaigns.adventures.show', [
+                            'campaign' => $campaign->id,
+                            'adventure' => $adventure->id,
+                        ]));
+        } else {
+            return $this->sendMessage('Cannot persist', 500);
+        }
+    }
+
+    public function show(Campaign $campaign, Adventure $adventure)
+    {
+        if ($adventure->campaign_id != $campaign->id) {
+            throw new ModelNotFoundException();
+        }
+        return new AdventureResource($adventure);
+    }
+
+    public function update(UpdateAdventure $request, Campaign $campaign, Adventure $adventure)
+    {
+        if ($adventure->campaign_id != $campaign->id) {
+            throw new ModelNotFoundException();
+        }
+        $validated = $request->validated();
+        if ($adventure->update($validated)) {
+            return $this->sendMessage('Persisted successfully');
+        } else {
+            return $this->sendMessage('Cannot persist', 500);
+        }
+    }
+
+    public function destroy(Campaign $campaign, Adventure $adventure)
+    {
+        if ($adventure->campaign_id != $campaign->id) {
+            throw new ModelNotFoundException();
+        }
+        if ($adventure->delete()) {
+            return $this->sendMessage('Destroyed sucessfully');
+        } else {
+            return $this->sendMessage('Cannot destroy', 500);
+        }
+    }
+}

--- a/app/Http/Requests/Adventures/StoreAdventure.php
+++ b/app/Http/Requests/Adventures/StoreAdventure.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Adventures;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreAdventure extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|max:100',
+            'description' => 'nullable',
+        ];
+    }
+}

--- a/app/Http/Requests/Adventures/UpdateAdventure.php
+++ b/app/Http/Requests/Adventures/UpdateAdventure.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Adventures;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateAdventure extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|max:100',
+            'description' => 'nullable',
+        ];
+    }
+}

--- a/app/Http/Resources/Adventures/Adventure.php
+++ b/app/Http/Resources/Adventures/Adventure.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Resources\Adventures;
+
+use App\Http\Resources\LinkedResource;
+use Illuminate\Support\Facades\URL;
+
+class Adventure extends LinkedResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'description' => $this->description,
+        ];
+    }
+
+    public function links($request)
+    {
+        return [
+            'self' => URL::route('campaigns.adventures.show', [
+                'campaign' => $this->campaign_id,
+                'adventure' => $this->id,
+            ]),
+            'campaign' => URL::route('campaigns.show', ['campaign' => $this->campaign_id]),
+        ];
+    }
+}

--- a/app/Http/Resources/Adventures/AdventureCollection.php
+++ b/app/Http/Resources/Adventures/AdventureCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources\Adventures;
+
+use App\Http\Resources\LinkedCollection;
+
+class AdventureCollection extends LinkedCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,6 +23,7 @@ Route::apiResource("spells", 'SpellController');
 Route::apiResource('users', 'User\UserController');
 Route::apiResource('characters', 'CharacterController');
 Route::apiResource('campaigns', 'CampaignsController');
+Route::apiResource('campaigns.adventures', 'AdventuresController');
 
 Route::prefix('auth')->group(function() {
     Route::resource('sessions', 'Api\Auth\SessionsController')->only(['store']);

--- a/tests/Feature/Api/AdventuresControllerTest.php
+++ b/tests/Feature/Api/AdventuresControllerTest.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+use App\Adventure;
+use App\User;
+use App\Campaign;
+
+class AdventuresControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected $user;
+
+    protected $campaign1;
+
+    protected $campaign2;
+
+    protected $adventure1;
+
+    protected $adventure2;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = factory(User::class)->create();
+        $this->campaign1 = factory(Campaign::class)->create([
+            'gamemaster_id' => $this->user->id,
+        ]);
+        $this->campaign2 = factory(Campaign::class)->create([
+            'gamemaster_id' => $this->user->id,
+        ]);
+        $this->adventure1 = factory(Adventure::class)->create([
+            'campaign_id' => $this->campaign1->id,
+            'title' => 'The Haunted Forest',
+            'description' => 'What kind of mistery would emerge',
+        ]);
+        $this->adventure2 = factory(Adventure::class)->create([
+            'campaign_id' => $this->campaign2->id,
+            'title' => 'The Dangerous Animal',
+            'description' => 'An animal very dangerous',
+        ]);
+    }
+
+    public function testIndexSucceeds()
+    {
+        $this->actingAs($this->user, 'jwt')
+             ->json('get', "/api/campaigns/{$this->campaign2->id}/adventures")
+             ->assertStatus(200)
+             ->assertJson([
+                 'data' => [
+                     [
+                         'id' => $this->adventure2->id,
+                         'title' => 'The Dangerous Animal',
+                         'description' => 'An animal very dangerous',
+                     ],
+                 ],
+             ]);
+    }
+
+    public function testIndexFailsIfCampaignNotFound()
+    {
+        $this->campaign2->delete();
+        $this->actingAs($this->user, 'jwt')
+             ->json('get', "/api/campaigns/{$this->campaign2->id}/adventures")
+             ->assertStatus(404);
+    }
+
+    public function testIndexFailsIfNotAuthenticated()
+    {
+        $this->json('get', "/api/campaigns/{$this->campaign2->id}/adventures")
+             ->assertStatus(401);
+    }
+
+    public function testShowSucceeds()
+    {
+        $this->actingAs($this->user, 'jwt')
+             ->json('get', "/api/campaigns/{$this->campaign2->id}/adventures/{$this->adventure2->id}")
+             ->assertStatus(200)
+             ->assertJson([
+                 'data' => [
+                     'id' => $this->adventure2->id,
+                     'title' => 'The Dangerous Animal',
+                     'description' => 'An animal very dangerous',
+                 ],
+             ]);
+    }
+
+    public function testShowFailsIfUnauthenticated()
+    {
+        $this->json('get', "/api/campaigns/{$this->campaign2->id}/adventures/{$this->adventure2->id}")
+             ->assertStatus(401);
+    }
+
+    public function testShowFailsIfNotExists()
+    {
+        $this->adventure2->delete();
+        $this->actingAs($this->user, 'jwt')
+             ->json('get', "/api/campaigns/{$this->campaign2->id}/adventures/{$this->adventure2->id}")
+             ->assertStatus(404);
+    }
+
+    public function testShowFailsIfCampaignMismatches()
+    {
+        $this->actingAs($this->user, 'jwt')
+             ->json('get', "/api/campaigns/{$this->campaign1->id}/adventures/{$this->adventure2->id}")
+             ->assertStatus(404);
+    }
+
+    public function testStoreSucceeds()
+    {
+        $payload = [
+            'title' => 'The Evil Tower',
+            'description' => 'Plant 3: Demons',
+        ];
+        $this->actingAs($this->user, 'jwt')
+             ->json('post', "/api/campaigns/{$this->campaign2->id}/adventures", $payload)
+             ->assertStatus(201)
+             ->assertHeader('Location');
+        $this->assertDatabaseHas('adventures', [
+            'title' => 'The Evil Tower',
+            'description' => 'Plant 3: Demons',
+            'campaign_id' => $this->campaign2->id,
+        ]);
+    }
+
+    public function testStoreFailsIfUnauthenticated()
+    {
+        $payload = [
+            'title' => 'The Evil Tower',
+            'description' => 'Plant 3: Demons',
+        ];
+        $this->json('post', "/api/campaigns/{$this->campaign2->id}/adventures", $payload)
+             ->assertStatus(401);
+    }
+
+    public function testStoreFailsIfInvalid()
+    {
+        $payload = [
+            'description' => 'Plant 3: Demons',
+        ];
+        $this->actingAs($this->user, 'jwt')
+             ->json('post', "/api/campaigns/{$this->campaign2->id}/adventures", $payload)
+             ->assertStatus(422);
+    }
+
+    public function testStoreIntegration()
+    {
+        $payload = [
+            'title' => 'The Evil Tower',
+            'description' => 'Plant 3: Demons',
+        ];
+
+        $response = $this->actingAs($this->user, 'jwt')
+                         ->json('post', "/api/campaigns/{$this->campaign2->id}/adventures", $payload);
+        $response->assertStatus(201);
+
+        $this->actingAs($this->user, 'jwt')
+             ->json('get', $response->headers->get('Location'))
+             ->assertJson([
+                 'data' => [
+                     'title' => 'The Evil Tower',
+                     'description' => 'Plant 3: Demons',
+                 ],
+             ]);
+    }
+
+    public function testUpdateSucceeds()
+    {
+        $payload = ['title' => 'A Dangerous Creature'];
+        $this->actingAs($this->user, 'jwt')
+             ->json('put', "/api/campaigns/{$this->campaign2->id}/adventures/{$this->adventure2->id}", $payload)
+             ->assertStatus(200);
+        $this->assertDatabaseHas('adventures', [
+            'id' => $this->adventure2->id,
+            'title' => 'A Dangerous Creature',
+            'description' => 'An animal very dangerous',
+            'campaign_id' => $this->campaign2->id,
+        ]);
+    }
+
+    public function testUpdateFailsIfNotValid()
+    {
+        $payload = ['title' => ''];
+        $this->actingAs($this->user, 'jwt')
+             ->json('put', "/api/campaigns/{$this->campaign2->id}/adventures/{$this->adventure2->id}", $payload)
+             ->assertStatus(422);
+    }
+
+    public function testUpdateFailsIfUnauthenticated()
+    {
+        $payload = ['title' => 'A Dangerous Creature'];
+        $this->json('put', "/api/campaigns/{$this->campaign2->id}/adventures/{$this->adventure2->id}", $payload)
+             ->assertStatus(401);
+    }
+
+    public function testUpdateFailsIfCampaignMismatches()
+    {
+        $payload = ['title' => 'A Dangerous Creature'];
+        $this->actingAs($this->user, 'jwt')
+             ->json('put', "/api/campaigns/{$this->campaign1->id}/adventures/{$this->adventure2->id}", $payload)
+             ->assertStatus(404);
+    }
+
+    public function testUpdateIntegration()
+    {
+        $payload = ['title' => 'A Dangerous Creature'];
+        $this->actingAs($this->user, 'jwt')
+             ->json('put', "/api/campaigns/{$this->campaign2->id}/adventures/{$this->adventure2->id}", $payload)
+             ->assertStatus(200);
+        $this->actingAs($this->user, 'jwt')
+             ->json('get', "/api/campaigns/{$this->campaign2->id}/adventures/{$this->adventure2->id}")
+             ->assertStatus(200)
+             ->assertJson([
+                 'data' => [
+                     'title' => 'A Dangerous Creature',
+                     'description' => 'An animal very dangerous',
+                 ],
+             ]);
+    }
+
+    public function testDestroySucceeds()
+    {
+        $this->actingAs($this->user, 'jwt')
+             ->json('delete', "/api/campaigns/{$this->campaign2->id}/adventures/{$this->adventure2->id}")
+             ->assertStatus(200);
+        $this->assertDeleted($this->adventure2);
+    }
+
+    public function testDestroyFailsIfUnauthenticated()
+    {
+        $this->json('delete', "/api/campaigns/{$this->campaign2->id}/adventures/{$this->adventure2->id}")
+             ->assertStatus(401);
+    }
+
+    public function testDestroyFailsIfCampaignMismatches()
+    {
+        $this->actingAs($this->user, 'jwt')
+             ->json('delete', "/api/campaigns/{$this->campaign1->id}/adventures/{$this->adventure2->id}")
+             ->assertStatus(404);
+    }
+
+    public function testDestroyIntegration()
+    {
+        $this->actingAs($this->user, 'jwt')
+             ->json('delete', "/api/campaigns/{$this->campaign2->id}/adventures/{$this->adventure2->id}")
+             ->assertStatus(200);
+        $this->actingAs($this->user, 'jwt')
+             ->json('get', "/api/campaigns/{$this->campaign2->id}/adventures/{$this->adventure2->id}")
+             ->assertStatus(404);
+    }
+}


### PR DESCRIPTION
This commit will add a controller to handle creation, retrieval,
update and deletion of adventures. It adds a set of linked resources
to present adventures, and a set of requests to receive adventures.

Closes #41