### PR TITLE
fix: cannot update campaign if I repeat the title

### DIFF
--- a/app/Http/Requests/Campaign/UpdateCampaign.php
+++ b/app/Http/Requests/Campaign/UpdateCampaign.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Campaign;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateCampaign extends FormRequest
 {
@@ -24,7 +25,12 @@ class UpdateCampaign extends FormRequest
     public function rules()
     {
         return [
-            'title' => 'sometimes|required|unique:campaigns|max:100',
+            'title' => [
+                'sometimes',
+                'required',
+                'max:100',
+                Rule::unique('campaigns')->ignoreModel($this->campaign),
+            ],
             'description' => 'nullable',
         ];
     }

--- a/tests/Feature/Api/CampaignsControllerTest.php
+++ b/tests/Feature/Api/CampaignsControllerTest.php
@@ -142,14 +142,17 @@ class CampaignsControllerTest extends TestCase
 
     public function testUpdateSucceeds()
     {
-        $payload = ['title' => 'Dark days are coming'];
+        $payload = [
+            'title' => 'The Lord of the Rings',
+            'description' => 'The original',
+        ];
         $this->actingAs($this->gamemaster, 'jwt')
              ->json('put', "/api/campaigns/{$this->campaign1->id}", $payload)
              ->assertStatus(200);
         $this->assertDatabaseHas('campaigns', [
             'id' => $this->campaign1->id,
-            'title' => 'Dark days are coming',
-            'description' => 'The original, except we slaughtered the book',
+            'title' => 'The Lord of the Rings',
+            'description' => 'The original',
         ]);
     }
 


### PR DESCRIPTION
When updating a campaign, I found that if the payload send as PUT
includes an unmodified copy of the title, it will be marked as a
validation error because there already exist a same record in the
database with this title; which is the expected behaviour because it is
the same record.

To be clear, if I create a campaign:

    POST /api/campaigns => { title: "My title", description: "Desc" }
    Location: /api/campaigns/1

And then update it this way:

    PUT /api/campaigns/1 => { title: "My title", description: "New" }

It should not fail because I submit the same title in the payload due to
"a campaign called 'My title' already exists", because of course it
does.